### PR TITLE
Add Advanced Professional WordPress Developer certification

### DIFF
--- a/content/cv/education/advanced-professional-wordpress-developer.mdx
+++ b/content/cv/education/advanced-professional-wordpress-developer.mdx
@@ -1,0 +1,5 @@
+---
+title: Advanced Professional WordPress Developer
+date: June 2026
+---
+An advanced industry certification validating professional-level expertise in WordPress development, covering architecture, security, performance, and the WordPress APIs. [View credential](https://sei.caveon.com/score/WyI5OTY3YjdmOS0wZjg0LTQ0YzgtOTcyNi02ZjkwZGJkNTVmMWQiLGZhbHNlXQ.0oUWo83_mQGLv3RKXeZWZQxm9Zs).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3569,10 +3569,6 @@ packages:
     resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
     engines: {node: 18 || 20 || >=22}
 
-  minimatch@10.2.4:
-    resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
-    engines: {node: 18 || 20 || >=22}
-
   minimatch@3.1.3:
     resolution: {integrity: sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==}
 
@@ -8979,10 +8975,6 @@ snapshots:
   mimic-fn@1.2.0: {}
 
   min-indent@1.0.1: {}
-
-  minimatch@10.2.4:
-    dependencies:
-      brace-expansion: 5.0.3
 
   minimatch@10.2.4:
     dependencies:


### PR DESCRIPTION
## What

Adds a new Education entry for the **Advanced Professional WordPress Developer** certification (Caveon SEI), passed 26 June 2026.

## Where it appears

New file: `content/cv/education/advanced-professional-wordpress-developer.mdx`

Renders in the **Education** section of the CV page. Because `useAllEducation` loads entries in glob (alphabetical filename) order with no explicit sort, the `advanced-...` filename places this newest qualification **first** in the list, above `cemap`/`certrbcp`/`gcse`.

## Details

- Frontmatter matches existing education entries (`title` + `date` strings) — passes the `hasTitle`/`hasDateString` validator.
- Body includes a public **View credential** verification link (the shareable score-report URL).
- Verified the frontmatter parses cleanly with `gray-matter` (the same lib the site uses).

## Open to feedback

- Wording of the description
- Whether you want the credential link inline (as now) vs. a dedicated button (would need a small template tweak to render a link field for education entries)
- Date format (`June 2026` to match the others; happy to make it a specific day)