### PR TITLE
Update WordPress certification credential link to Credential.net

### DIFF
--- a/content/cv/education/advanced-professional-wordpress-developer.mdx
+++ b/content/cv/education/advanced-professional-wordpress-developer.mdx
@@ -2,4 +2,4 @@
 title: Advanced Professional WordPress Developer
 date: June 2026
 ---
-An advanced industry certification validating professional-level expertise in WordPress development, covering architecture, security, performance, and the WordPress APIs. [View credential](https://sei.caveon.com/score/WyI5OTY3YjdmOS0wZjg0LTQ0YzgtOTcyNi02ZjkwZGJkNTVmMWQiLGZhbHNlXQ.0oUWo83_mQGLv3RKXeZWZQxm9Zs).
+An advanced industry certification validating professional-level expertise in WordPress development, covering architecture, security, performance, and the WordPress APIs. [View credential](https://automattic.credential.net/d1ed194c-880c-4b43-82a3-72d043473e34#acc.qw5936Xx).


### PR DESCRIPTION
## What

Updates the **View credential** link on the Advanced Professional WordPress Developer education entry.

The previous PR (#1666, merged) used the Caveon score-report URL. This swaps it for the official **Automattic Credential.net** verification URL James wants to share publicly:

`https://automattic.credential.net/d1ed194c-880c-4b43-82a3-72d043473e34#acc.qw5936Xx`

## Change

One line in `content/cv/education/advanced-professional-wordpress-developer.mdx` — just the link target. No other content touched.

## Verified

- `pnpm run build` passes locally (MDX compiles, site builds clean).
- The `#acc.qw5936Xx` fragment is valid in the markdown link and preserved in the build.